### PR TITLE
Gamecube wheel support

### DIFF
--- a/src/Gamecube.cpp
+++ b/src/Gamecube.cpp
@@ -70,14 +70,26 @@ bool Gamecube_::end(const uint8_t pin){
 	// Turns off rumble by sending a normal reading request
 	// and discards the information
 	Gamecube_Data_t report;
-	return read(pin, report, false);
+  Gamecube_Status_t status;
+	return read(pin, status, report, false);
 }
 
 
-bool Gamecube_::read(const uint8_t pin, Gamecube_Data_t &report, const bool rumble)
-{
-	// command to send to the gamecube, LSB is rumble
-	uint8_t command[] = { 0x40, 0x03, rumble & 0x01 };
+bool Gamecube_::read(const uint8_t pin, Gamecube_Status_t &status, Gamecube_Data_t &report, const bool rumble)
+{  
+  uint8_t command[3];
+  switch (status.device){
+  case NINTENDO_DEVICE_GC_WHEEL:
+    command[0] = 0x30;
+    command[1] = 0x00;
+    command[2] = 0x00;
+    break;
+  default:
+    // command to send to the gamecube, LSB is rumble
+    command[0] = 0x40;
+    command[1] = 0x03;
+    command[2] = rumble & 0x01;
+  }
 
 	// send the command and read in data
 	uint8_t receivedBytes = gc_n64_send_get(pin, command, sizeof(command), (uint8_t*)&report, sizeof(report));

--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 
 // gamecube controller device status ids
 #define NINTENDO_DEVICE_GC_WIRED 0x0900
+#define NINTENDO_DEVICE_GC_WHEEL 0x0800
 
 // dpad directions
 #define NINTENDO_GAMECUBE_DPAD_CENTERED 0
@@ -115,7 +116,7 @@ public:
 	bool end(const uint8_t pin);
 
 	// default no rumble
-	bool read(const uint8_t pin, Gamecube_Data_t &report, const bool rumble = false);
+	bool read(const uint8_t pin, Gamecube_Status_t &status, Gamecube_Data_t &report, const bool rumble = false);
 	inline void write(void){} // TODO
 };
 


### PR DESCRIPTION
There would be a better way for accessing device ID from read function without adding extra "status" parameter, but it works.