### PR TITLE
Fix bug in N64 API

### DIFF
--- a/src/N64API.hpp
+++ b/src/N64API.hpp
@@ -43,7 +43,7 @@ void CN64Controller::reset(void)
 bool CN64Controller::begin(void)
 {
     // Try to init the controller
-    if (!gc_init(pin, &status))
+    if (!n64_init(pin, &status))
     {
         // Reset in any case, as some bytes may have been written.
         reset();


### PR DESCRIPTION
The N64 API did not work, and upon further inspection, it was calling gc_init instead of n64_init, this fixes that, and the API works now! (on a Arduino Pro Micro clone with a voltage converter, in my case)

edit: [here](https://github.com/OpenRetroPad/OpenRetroPad/commit/a3a4e9d8735b9429b71aa0ac921fee1da954247c) is how I use+tested it