### PR TITLE
Add Pokémon Colosseum,XD support

### DIFF
--- a/src/Gamecube.c
+++ b/src/Gamecube.c
@@ -149,6 +149,45 @@ uint8_t gc_write(const uint8_t pin, Gamecube_Status_t* status, Gamecube_Origin_t
             ret = 6;
         }
     }
+    // Add Support Pokemon Colosseum,XD
+    // Get data. Do not check last byte (command[2]), as the flags are unknown
+    else if (receivedBytes == 3 && command[0] == 0x40 && command[1] == 0x00)
+    {
+        gc_n64_send(report->raw8, sizeof(Gamecube_Report_t), modePort, outPort, bitMask);
+        ret = 3;
+        // The first byte probably flags a gamecube reading (0x40), as the same
+        // protocol is also used for N64. The lower nibble seems to be the mode:
+        // 0x40 (followed by 2 bytes) reading
+        // 0x41 get origin (1 byte)
+        // 0x42 (followed by 2 bytes) seems to force mode 0x02 below
+        // 0x43 (followed by 2 bytes) seems to force mode 0x02 below
+
+        // The 2nd byte (command[1]) seems to request a special data format.
+        // I've noticed formats that merge the L + R data.
+        // There seem to be only 4 data formats, the rest is ignore.
+        // 0x00 First 4 bytes: buttons0+1 + X + Y, C-Stick, L+R minimum of both, 0x00 fixed
+        // 0x01 First 4 bytes: buttons0+1 + X + Y, C-Stick Horizontal only, R, L, 0x00 fixed
+        // 0x02 First 4 bytes: buttons0+1 + X + Y, C-Stick Horizontal only, L+R minimum of both, 0x02 fixed, 0x01 fixed
+        // 0x03 Normal reading
+
+        // I've seen 3 last options for the last byte (command[2]):
+        // 0x00 Normal reading
+        // 0x01 Enable rumble
+        // 0x02 Normal reading, rumble was at least called once
+        // 0x03 ??? - never seen so far
+        // Rumble: 1, 5, 9, 13, 17, ...
+        // You can see that only 4 of those requests are possible,
+        // the gamecube will ignore the left 6 MSB.
+        if((command[2] % 4) == 0x01){
+            ret = 4;
+        }
+        else if((command[2] % 4) == 0x02){
+            ret = 5;
+        }
+        else if((command[2] % 4) == 0x03){
+            ret = 6;
+        }
+    }
 
     // End of time sensitive code
     SREG = oldSREG;

--- a/src/Gamecube.c
+++ b/src/Gamecube.c
@@ -78,33 +78,30 @@ bool gc_read(const uint8_t pin, Gamecube_Report_t* report, const bool rumble)
 // Gamecube Console
 //================================================================================
 
-void gc_report_convert(Gamecube_Report_t* report, Gamecube_Different_Report_t* dif, uint8_t mode)
+void gc_report_convert(Gamecube_Report_t* report, uint8_t mode)
 {
-    memcpy(dif, report, sizeof(dif));
     if (mode == 1)
     {
-        dif->mode1.cxAxis = report->cxAxis >> 4;
-        dif->mode1.cyAxis = report->cyAxis >> 4;
-        dif->mode1.left = report->left;
-        dif->mode1.right = report->right;
-        dif->mode1.analogA = 0;
-        dif->mode1.analogB = 0;
+        report->mode1.cxAxis = report->cxAxis >> 4;
+        report->mode1.cyAxis = report->cyAxis >> 4;
+        report->mode1.left = report->left;
+        report->mode1.right = report->right;
+        report->mode1.analogA = 0;
+        report->mode1.analogB = 0;
     }
     else if (mode == 2)
     {
-        dif->mode2.cxAxis = report->cxAxis >> 4;
-        dif->mode2.cyAxis = report->cyAxis >> 4;
-        dif->mode2.left = report->left >> 4;
-        dif->mode2.right = report->right >> 4;
-        dif->mode2.analogA = 0;
-        dif->mode2.analogB = 0;
+        report->mode2.cxAxis = report->cxAxis >> 4;
+        report->mode2.cyAxis = report->cyAxis >> 4;
+        report->mode2.left = report->left >> 4;
+        report->mode2.right = report->right >> 4;
+        report->mode2.analogA = 0;
+        report->mode2.analogB = 0;
     }
     else if (mode == 4)
     {
-        dif->mode4.cxAxis = report->cxAxis;
-        dif->mode4.cyAxis = report->cyAxis;
-        dif->mode4.analogA = 0;
-        dif->mode4.analogB = 0;
+        report->mode4.analogA = 0;
+        report->mode4.analogB = 0;
     }
     else if (mode == 3)
     {
@@ -112,12 +109,10 @@ void gc_report_convert(Gamecube_Report_t* report, Gamecube_Different_Report_t* d
     }
     else
     {
-        dif->mode0.cxAxis = report->cxAxis;
-        dif->mode0.cyAxis = report->cyAxis;
-        dif->mode0.left = report->left >> 4;
-        dif->mode0.right = report->right >> 4;
-        dif->mode0.analogA = 0;
-        dif->mode0.analogB = 0;
+        report->mode0.left = report->left >> 4;
+        report->mode0.right = report->right >> 4;
+        report->mode0.analogA = 0;
+        report->mode0.analogB = 0;
     }
 }
 
@@ -157,9 +152,8 @@ uint8_t gc_write(const uint8_t pin, Gamecube_Status_t* status, Gamecube_Origin_t
     // Get data. Do not check last byte (command[2]), as the flags are unknown
     else if (receivedBytes == 3 && command[0] == 0x40 && command[1] <= 0x07)
     {
-        Gamecube_Different_Report_t dif;
-        gc_report_convert(report, &dif, command[1]);
-        gc_n64_send(dif.raw8, sizeof(Gamecube_Different_Report_t), modePort, outPort, bitMask);
+        gc_report_convert(report, command[1]);
+        gc_n64_send(report->raw8, sizeof(Gamecube_Report_t), modePort, outPort, bitMask);
         ret = 3;
         // The first byte probably flags a gamecube reading (0x40), as the same
         // protocol is also used for N64. The lower nibble seems to be the mode:

--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -85,51 +85,6 @@ typedef union{
         uint8_t cyAxis;
         uint8_t left;
         uint8_t right;
-    };
-} Gamecube_Report_t;
-
-typedef union{
-    // 8 bytes of datareport that we get from the controller
-    uint8_t raw8[8];
-    uint16_t raw16[0];
-    uint32_t raw32[0];
-
-    struct{
-        uint8_t buttons0;
-        union{
-            uint8_t buttons1;
-            uint8_t dpad : 4;
-        };
-    };
-
-    struct {
-        // first data byte (bitfields are sorted in LSB order)
-        uint8_t a : 1;
-        uint8_t b : 1;
-        uint8_t x : 1;
-        uint8_t y : 1;
-        uint8_t start : 1;
-        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
-        uint8_t errlatch : 1;
-        uint8_t errstat : 1;
-
-        // second data byte
-        uint8_t dleft : 1;
-        uint8_t dright : 1;
-        uint8_t ddown : 1;
-        uint8_t dup : 1;
-        uint8_t z : 1;
-        uint8_t r : 1;
-        uint8_t l : 1;
-        uint8_t high1 : 1;
-
-        // 3rd-8th data byte
-        uint8_t xAxis;
-        uint8_t yAxis;
-        uint8_t cxAxis;
-        uint8_t cyAxis;
-        uint8_t left;
-        uint8_t right;
     }; // mode3 (default reading mode)
 
     struct {
@@ -261,7 +216,8 @@ typedef union{
         uint8_t analogA;
         uint8_t analogB;
     } mode4;
-} Gamecube_Different_Report_t;
+
+} Gamecube_Report_t;
 
 // Gamecube an N64 use the same status schema
 typedef Gamecube_N64_Status_t Gamecube_Status_t;

--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -88,6 +88,180 @@ typedef union{
     };
 } Gamecube_Report_t;
 
+typedef union{
+    // 8 bytes of datareport that we get from the controller
+    uint8_t raw8[8];
+    uint16_t raw16[0];
+    uint32_t raw32[0];
+
+    struct{
+        uint8_t buttons0;
+        union{
+            uint8_t buttons1;
+            uint8_t dpad : 4;
+        };
+    };
+
+    struct {
+        // first data byte (bitfields are sorted in LSB order)
+        uint8_t a : 1;
+        uint8_t b : 1;
+        uint8_t x : 1;
+        uint8_t y : 1;
+        uint8_t start : 1;
+        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
+        uint8_t errlatch : 1;
+        uint8_t errstat : 1;
+
+        // second data byte
+        uint8_t dleft : 1;
+        uint8_t dright : 1;
+        uint8_t ddown : 1;
+        uint8_t dup : 1;
+        uint8_t z : 1;
+        uint8_t r : 1;
+        uint8_t l : 1;
+        uint8_t high1 : 1;
+
+        // 3rd-8th data byte
+        uint8_t xAxis;
+        uint8_t yAxis;
+        uint8_t cxAxis;
+        uint8_t cyAxis;
+        uint8_t left;
+        uint8_t right;
+    };
+
+    struct {
+        // first data byte (bitfields are sorted in LSB order)
+        uint8_t a : 1;
+        uint8_t b : 1;
+        uint8_t x : 1;
+        uint8_t y : 1;
+        uint8_t start : 1;
+        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
+        uint8_t errlatch : 1;
+        uint8_t errstat : 1;
+
+        // second data byte
+        uint8_t dleft : 1;
+        uint8_t dright : 1;
+        uint8_t ddown : 1;
+        uint8_t dup : 1;
+        uint8_t z : 1;
+        uint8_t r : 1;
+        uint8_t l : 1;
+        uint8_t high1 : 1;
+
+        // 3rd-8th data byte
+        uint8_t xAxis;
+        uint8_t yAxis;
+        uint8_t cxAxis;
+        uint8_t cyAxis;
+        /*
+        uint8_t left;
+        uint8_t right;
+        */
+        uint8_t left : 4;
+        uint8_t right : 4;
+        uint8_t analogA : 4;
+        uint8_t analogB : 4;
+    } Mode0;
+
+    struct {
+        // first data byte (bitfields are sorted in LSB order)
+        uint8_t a : 1;
+        uint8_t b : 1;
+        uint8_t x : 1;
+        uint8_t y : 1;
+        uint8_t start : 1;
+        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
+        uint8_t errlatch : 1;
+        uint8_t errstat : 1;
+
+        // second data byte
+        uint8_t dleft : 1;
+        uint8_t dright : 1;
+        uint8_t ddown : 1;
+        uint8_t dup : 1;
+        uint8_t z : 1;
+        uint8_t r : 1;
+        uint8_t l : 1;
+        uint8_t high1 : 1;
+
+        // 3rd-8th data byte
+        uint8_t xAxis;
+        uint8_t yAxis;
+        uint8_t cxAxis : 4;
+        uint8_t cyAxis : 4;
+        uint8_t left;
+        uint8_t right;
+        uint8_t analogA : 4;
+        uint8_t analogB : 4;
+    } Mode1;
+
+    struct {
+        // first data byte (bitfields are sorted in LSB order)
+        uint8_t a : 1;
+        uint8_t b : 1;
+        uint8_t x : 1;
+        uint8_t y : 1;
+        uint8_t start : 1;
+        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
+        uint8_t errlatch : 1;
+        uint8_t errstat : 1;
+
+        // second data byte
+        uint8_t dleft : 1;
+        uint8_t dright : 1;
+        uint8_t ddown : 1;
+        uint8_t dup : 1;
+        uint8_t z : 1;
+        uint8_t r : 1;
+        uint8_t l : 1;
+        uint8_t high1 : 1;
+
+        // 3rd-8th data byte
+        uint8_t xAxis;
+        uint8_t yAxis;
+        uint8_t cxAxis : 4;
+        uint8_t cyAxis : 4;
+        uint8_t left : 4;
+        uint8_t right : 4;
+        uint8_t analogA;
+        uint8_t analogB;
+    } Mode2;
+
+    struct {
+        // first data byte (bitfields are sorted in LSB order)
+        uint8_t a : 1;
+        uint8_t b : 1;
+        uint8_t x : 1;
+        uint8_t y : 1;
+        uint8_t start : 1;
+        uint8_t origin : 1; // Indicates if GetOrigin(0x41) was called (LOW)
+        uint8_t errlatch : 1;
+        uint8_t errstat : 1;
+
+        // second data byte
+        uint8_t dleft : 1;
+        uint8_t dright : 1;
+        uint8_t ddown : 1;
+        uint8_t dup : 1;
+        uint8_t z : 1;
+        uint8_t r : 1;
+        uint8_t l : 1;
+        uint8_t high1 : 1;
+
+        // 3rd-8th data byte
+        uint8_t xAxis;
+        uint8_t yAxis;
+        uint8_t cxAxis;
+        uint8_t cyAxis;
+        uint8_t analogA;
+        uint8_t analogB;
+    } Mode4;
+} Gamecube_Different_Report_t;
 
 // Gamecube an N64 use the same status schema
 typedef Gamecube_N64_Status_t Gamecube_Status_t;

--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -130,7 +130,7 @@ typedef union{
         uint8_t cyAxis;
         uint8_t left;
         uint8_t right;
-    };
+    }; // mode3 (default reading mode)
 
     struct {
         // first data byte (bitfields are sorted in LSB order)
@@ -166,7 +166,7 @@ typedef union{
         uint8_t right : 4;
         uint8_t analogA : 4;
         uint8_t analogB : 4;
-    } Mode0;
+    } mode0;
 
     struct {
         // first data byte (bitfields are sorted in LSB order)
@@ -198,7 +198,7 @@ typedef union{
         uint8_t right;
         uint8_t analogA : 4;
         uint8_t analogB : 4;
-    } Mode1;
+    } mode1;
 
     struct {
         // first data byte (bitfields are sorted in LSB order)
@@ -230,7 +230,7 @@ typedef union{
         uint8_t right : 4;
         uint8_t analogA;
         uint8_t analogB;
-    } Mode2;
+    } mode2;
 
     struct {
         // first data byte (bitfields are sorted in LSB order)
@@ -260,7 +260,7 @@ typedef union{
         uint8_t cyAxis;
         uint8_t analogA;
         uint8_t analogB;
-    } Mode4;
+    } mode4;
 } Gamecube_Different_Report_t;
 
 // Gamecube an N64 use the same status schema


### PR DESCRIPTION
Hello, thanks for the great library.
I found a problem where data could not be sent only when running Pokémon Colosseum/XD.
When running Pokémon Colosseum/XD, the GameCube seems to return different data than the other games.
However, i solved the problem by copying line 114 and below of Gamecube.c and changing
`else if (receivedBytes == 3 && command[0] == 0x40 && command[1] == 0x03)`
to
`else if (receivedBytes == 3 && command[0] == 0x40 && command[1] == 0x00)`
If you are comfortable with this change, I would appreciate it if you could merge the code.
Thank you.