### PR TITLE
Added support for different reading modes

### DIFF
--- a/src/Gamecube.c
+++ b/src/Gamecube.c
@@ -121,7 +121,7 @@ uint8_t gc_write(const uint8_t pin, Gamecube_Status_t* status, Gamecube_Origin_t
         // If you are simply reading a real controller and mirroring that data to the console,
         // you should be fine. If you only modify the button or x/y axis values you are mostly safe.
         // If you experience any errors, please let me know. A detailed documentation of possible modes
-        // Can be found here:
+        // can be found here:
         // https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp#L167
 
         gc_n64_send(report->raw8, sizeof(Gamecube_Report_t), modePort, outPort, bitMask);

--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -57,6 +57,12 @@ typedef union{
         };
     };
 
+    // NOTE:
+    // This only represents reading mode 3!
+    // If you are using a different reading mode, make sure to arrange the data
+    // accordingly yourself. Pullrequests with different layouts via unions are welcome.
+    // More information about different reading modes can be found in the dolphin source:
+    // https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp#L167
     struct {
         // first data byte (bitfields are sorted in LSB order)
         uint8_t a : 1;


### PR DESCRIPTION
Replaces #25 and #31

The idea or this PR is to arrange the sending data in the Gamecube_Report_t itself and accept all reading modes (0-7) by default. The data structure represents reading mode 3, the other modes must be implemented on your own. It is possible, that most of the time the sending will work with 0x00 data if you do not care about the changed triggers.