### PR TITLE
Add N64 rumble pak support

### DIFF
--- a/examples/N64/N64Controller/N64Controller.ino
+++ b/examples/N64/N64Controller/N64Controller.ino
@@ -41,6 +41,16 @@ void loop()
     auto status = N64Controller.getStatus();
     auto report = N64Controller.getReport();
     print_n64_report(report, status);
+
+    // Rumble if button "A" was pressed
+    if (report.a)
+    {
+      N64Controller.setRumble(true);
+    }
+    else
+    {
+      N64Controller.setRumble(false);
+    }
     delay(100);
   }
   else
@@ -70,6 +80,13 @@ void print_n64_report(N64_Report_t &n64_report, N64_Status_t &n64_status)
       Serial.println(n64_status.device, HEX);
       break;
   }
+
+  // Print rumble state
+  Serial.print(F("Rumble "));
+  if (n64_status.rumble)
+    Serial.println(F("on"));
+  else
+    Serial.println(F("off"));
 
   // Prints the raw data from the controller
   Serial.println();

--- a/src/N64.c
+++ b/src/N64.c
@@ -41,7 +41,6 @@ bool n64_init(const uint8_t pin, N64_Status_t* status)
     return (receivedBytes == sizeof(N64_Status_t));
 }
 
-
 bool n64_read(const uint8_t pin, N64_Report_t* report)
 {
     // Command to send to the N64
@@ -53,6 +52,30 @@ bool n64_read(const uint8_t pin, N64_Report_t* report)
     // Return status information for optional use.
     // On error the report may have been modified!
     return (receivedBytes == sizeof(N64_Report_t));
+}
+
+void n64_writeRumble(const uint8_t pin, uint8_t writeVal) {
+    uint8_t writeRequest[35];
+    writeRequest[0] = 0x03;
+    writeRequest[1] = 0x80;
+    writeRequest[2] = 0x01;
+    memset(writeRequest + 3, writeVal, 32);
+    uint8_t writeResponse[1];
+    uint8_t receivedBytes = gc_n64_send_get(pin, writeRequest, sizeof(writeRequest), (uint8_t*)&writeResponse, sizeof(writeResponse));
+
+    uint8_t readRequest[3] = {0x02, 0x80, 0x01};
+    uint8_t readResponse[32];
+    uint8_t receivedBytes2 = gc_n64_send_get(pin, readRequest, sizeof(readRequest), (uint8_t*)&readResponse, sizeof(readResponse));
+}
+
+void n64_setRumble(const uint8_t pin, bool rumble) {
+    uint8_t request[35];
+    request[0] = 0x03;
+    request[1] = 0xc0;
+    request[2] = 0x1b;
+    memset(request + 3, rumble ? 0x01 : 0x00, 32);
+    uint8_t response[1];
+    uint8_t receivedBytes = gc_n64_send_get(pin, request, sizeof(request), (uint8_t*)&response, sizeof(response));
 }
 
 

--- a/src/N64.h
+++ b/src/N64.h
@@ -106,6 +106,10 @@ bool n64_init(const uint8_t pin, N64_Status_t* status);
 bool n64_read(const uint8_t pin, N64_Report_t* report);
 uint8_t n64_write(const uint8_t pin, N64_Status_t* status, N64_Report_t* report);
 
+// Functions to communicate with the rumble pak
+void n64_writeRumble(const uint8_t pin, uint8_t writeVal);
+void n64_setRumble(const uint8_t pin, bool rumble);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/N64API.h
+++ b/src/N64API.h
@@ -45,7 +45,7 @@ public:
     inline bool connected(void);
     inline bool read(void);
     inline bool getRumble(void);
-    //inline bool setRumble(bool rumble);
+    inline bool setRumble(bool rumble);
     inline bool end(void);
     inline N64_Status_t getStatus(void);
     inline N64_Report_t getReport(void);


### PR DESCRIPTION
Hi Nico.

This code adds rumble support for a physical controller with connected to the arduino.

It's based on:
https://sites.google.com/site/consoleprotocols/home/nintendo-joy-bus-documentation
https://github.com/DavidPagels/retro-pico-switch/blob/master/src/otherController/n64/N64Controller.cpp