### PR TITLE
Wavebird: Optimistically try to read other controllers

### DIFF
--- a/src/GamecubeAPI.hpp
+++ b/src/GamecubeAPI.hpp
@@ -87,8 +87,7 @@ bool CGamecubeController::read(void)
         }
     }
 
-
-    if (status.device == NINTENDO_DEVICE_GC_WIRED)
+    if (status.device != NINTENDO_DEVICE_GC_NONE && status.device != NINTENDO_DEVICE_GC_KEYBOARD)
     {
         // Read the controller, abort if it fails.
         // Additional information: If you press X + Y + Start on the controller for 3 seconds


### PR DESCRIPTION
Small change that makes my Wavebird controller work. It optimistically tries to read devices other than GameCube keyboard the same as a standard wired GameCube controller.