### PR TITLE
fix half-byte data structure endianness to fix Luigi's Mansion triggers

### DIFF
--- a/src/Gamecube.h
+++ b/src/Gamecube.h
@@ -118,10 +118,10 @@ typedef union{
         uint8_t left;
         uint8_t right;
         */
-        uint8_t left : 4;
         uint8_t right : 4;
-        uint8_t analogA : 4;
+        uint8_t left : 4;
         uint8_t analogB : 4;
+        uint8_t analogA : 4;
     } mode0;
 
     struct {
@@ -148,12 +148,12 @@ typedef union{
         // 3rd-8th data byte
         uint8_t xAxis;
         uint8_t yAxis;
-        uint8_t cxAxis : 4;
         uint8_t cyAxis : 4;
+        uint8_t cxAxis : 4;
         uint8_t left;
         uint8_t right;
-        uint8_t analogA : 4;
         uint8_t analogB : 4;
+        uint8_t analogA : 4;
     } mode1;
 
     struct {
@@ -180,10 +180,10 @@ typedef union{
         // 3rd-8th data byte
         uint8_t xAxis;
         uint8_t yAxis;
-        uint8_t cxAxis : 4;
         uint8_t cyAxis : 4;
-        uint8_t left : 4;
+        uint8_t cxAxis : 4;
         uint8_t right : 4;
+        uint8_t left : 4;
         uint8_t analogA;
         uint8_t analogB;
     } mode2;


### PR DESCRIPTION
AVR is little-endian, so within each byte the LSB must come first even though the MSB goes over the wire first.

Mode 0 was supposedly tested with Pokemon XD, but XD uses digital press, not analog, so it's not a good test.

In Luigi's Mansion, L and R functions were switched.

This was borne out looking at the data line on an oscilloscope with an OEM controller, an Arduino based digital controller, and a Phob 2 (RP2040 using Pico-Rectangle's comms).

Thanks to @mizuyoukanao for trying to port the alternate modes over to PhobGCC-SW, and Skozzy for reporting the issue in Luigi's Mansion.